### PR TITLE
Fix output / abort in `dspline_interp()` on certain nondisjoint xd & x

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dspline
 Title: Tools for computations with discrete splines
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: c(
    person("Addison", "Hu", 
            role = "aut"),

--- a/R/checks.R
+++ b/R/checks.R
@@ -61,4 +61,12 @@ check_nonneg_int <- function(x) {
     rlang::abort(sprintf("`%s` must be a nonnegative integer.", args[1]))
   }
 }
-  
+
+check_no_na <- function(x,
+                        x_arg = rlang::caller_arg(x), call = rlang::caller_call(),
+                        ...) {
+  if (anyNA(x)) {
+    rlang::abort(sprintf("`%s` must not have any NAs.", x_arg), call = call,
+                 ...)
+  }
+}

--- a/R/interpolation.R
+++ b/R/interpolation.R
@@ -71,6 +71,9 @@ dspline_interp <- function(v, k, xd, x, implicit = TRUE) {
   check_sorted(xd)
   check_length(xd, k+1, ">=")
   check_length(v, length(xd))
+  check_no_na(x)
+  check_no_na(xd)
+  check_no_na(v)
   rcpp_dspline_interp(v, k, xd, x, implicit)
 }
 

--- a/src/interpolation.cpp
+++ b/src/interpolation.cpp
@@ -67,7 +67,7 @@ NumericVector rcpp_dspline_interp(NumericVector v, int k, NumericVector xd, Nume
     for (int i = 0; i < nx; i++) {
       // Trivial case where x is one of the design points
       if (xd[J[i]] == x[i]) {
-        f[i] = v[i];
+        f[i] = v[J[i]];
         continue;
       }
 

--- a/tests/testthat/old-funs.R
+++ b/tests/testthat/old-funs.R
@@ -108,13 +108,13 @@ evalH = function(x0, k, jj, x=1:n/n) {
 library(Matrix)
 
 Id = function(n) {
-  return(bandSparse(n, k=0, diag=list(rep(1,n))))
+  return(bandSparse(n, k=0, diagonals=list(rep(1,n))))
 }
 
 # These are the "right" ones based on divided diffs
 getB = function(n, k, x=1:n/n) {
   I = Id(n)
-  D = bandSparse(n, k=c(-1,0), diag=list(rep(-1,n-1), rep(1,n)))
+  D = bandSparse(n, k=c(-1,0), diagonals=list(rep(-1,n-1), rep(1,n)))
   B = I
   for (i in Seq(1,k)) {
     wts = c(rep(1,i), i/(x[(i+1):n]-x[1:(n-i)]))
@@ -298,7 +298,7 @@ dbs.Bmat = function(k, x, a=NULL, b=NULL, xleft=NULL) {
         getD(k+2,k+1,z)[k+2] * tnp(v)(X(i+1))
     }
   }
-  return(bandSparse(n, k=0, diag=list(bvec)))
+  return(bandSparse(n, k=0, diagonals=list(bvec)))
 }
 
 # Faster and more stable way of evaluating DB-splines at the design

--- a/tests/testthat/test-dspline.R
+++ b/tests/testthat/test-dspline.R
@@ -214,7 +214,7 @@ test_that("Interpolation", {
   n = 10
   k = 2
   xd = sort(runif(n))
-  x = seq(0, 1, length=100)
+  x = seq(0, 1, length.out=100)
   v = xd^2 + 0.05 * rnorm(n)
   y1 = dspline_interp(v, k, xd, x, implicit = TRUE)
   y2 = dspline_interp(v, k, xd, x, implicit = FALSE)
@@ -238,7 +238,7 @@ test_that("Newton interpolation", {
   n = k+1
   xd = sort(runif(n))
   v = xd^k
-  x = seq(0, 1, length=100)
+  x = seq(0, 1, length.out=100)
   y1 = dspline_interp(v, k, xd, x, implicit = TRUE)
   y2 = dspline_interp(v, k, xd, x, implicit = FALSE)
   y3 = newton_interp(v, xd, x)

--- a/tests/testthat/test-dspline.R
+++ b/tests/testthat/test-dspline.R
@@ -221,6 +221,16 @@ test_that("Interpolation", {
   y3 = as.numeric(predict.tf.fitted(x, v, xd, k))
   expect_equal(y1, y2, tolerance = tol)
   expect_equal(y2, y3, tolerance = tol)
+  # "Wide query" requesting that xd be echoed back as well:
+  xd_wq = xd
+  x_wq = c(x, xd)
+  v_wq = v
+  y1_wq = dspline_interp(v_wq, k, xd_wq, x_wq, implicit = TRUE)
+  y2_wq = dspline_interp(v_wq, k, xd_wq, x_wq, implicit = FALSE)
+  y3_wq = as.numeric(predict.tf.fitted(x_wq, v_wq, xd_wq, k))
+  expect_equal(y1_wq, y2_wq, tolerance = tol)
+  expect_equal(y2_wq, y3_wq, tolerance = tol)
+  expect_equal(y3_wq, c(y3, v), tolerance = tol)
 })
 
 test_that("Newton interpolation", {

--- a/tests/testthat/test-dspline.R
+++ b/tests/testthat/test-dspline.R
@@ -231,6 +231,16 @@ test_that("Interpolation", {
   expect_equal(y1_wq, y2_wq, tolerance = tol)
   expect_equal(y2_wq, y3_wq, tolerance = tol)
   expect_equal(y3_wq, c(y3, v), tolerance = tol)
+  # "Wide all" situation with design points also including both the "true" query
+  # and "true" design points, with NAs in v:
+  xd_wa = c(x, xd)
+  x_wa = c(x, xd)
+  v_wa = c(rep(NA, length(x)), v)
+  o_wa = order(xd_wa)
+  xd_wa <- xd_wa[o_wa]
+  v_wa <- v_wa[o_wa]
+  expect_error(dspline_interp(v_wa, k, xd_wa, x_wa),
+               regexp = "`v` must not have any NAs")
 })
 
 test_that("Newton interpolation", {


### PR DESCRIPTION
- Fix `dspline_interp()` with `implicit = TRUE` and `x` including points from `xd`
- Make `dspline_interp()` with NAs in `v` abort. 

Resolves #16 