### PR TITLE
Fix examples

### DIFF
--- a/R/discrete_calculus.R
+++ b/R/discrete_calculus.R
@@ -99,7 +99,7 @@ divided_diff <- function(f, z) {
 #'   at design points.
 #' @export
 #' @examples
-#' xd = 1:10
+#' xd = 1:10 / 10
 #' discrete_deriv(function(x) x^2, 1, xd, xd)
 discrete_deriv <- function(f, k, xd, x) {
   check_nonneg_int(k)
@@ -173,7 +173,7 @@ discrete_deriv <- function(f, k, xd, x) {
 #'   points.
 #' @export
 #' @examples
-#' xd = 1:10
+#' xd = 1:10 / 10
 #' discrete_integ(function(x) 1, 1, xd, xd)
 discrete_integ <- function(f, k, xd, x) {
   check_nonneg_int(k)

--- a/R/discrete_calculus.R
+++ b/R/discrete_calculus.R
@@ -31,17 +31,16 @@
 #'
 #' @export
 #' @examples
-#' m = 4 
-#' f = runif(m)
-#' z = runif(m)
+#' f = runif(4)
+#' z = runif(4)
 #' divided_diff(f[1], z[1])
 #' f[1]
 #' divided_diff(f[1:2], z[1:2])
 #' (f[1]-f[2])/(z[1]-z[2])
 #' divided_diff(f[1:3], z[1:3])
 #' ((f[1]-f[2])/(z[1]-z[2]) - (f[2]-f[3])/(z[2]-z[3])) / (z[1]-z[3]) 
-#' divided_diff(f, 1:m)
-#' diff(f, diff = m-1) / factorial(m-1)
+#' divided_diff(f, 1:4)
+#' diff(f, diff = 3) / factorial(3)
 divided_diff <- function(f, z) {
   if (is.function(f)) f = sapply(z, f)
   else check_length(f, length(z))

--- a/R/discrete_calculus.R
+++ b/R/discrete_calculus.R
@@ -31,9 +31,17 @@
 #'
 #' @export
 #' @examples
-#' divided_diff(sin, 1:99 / 100 * 2 * pi)
-#' divided_diff(cos, 1:99 / 100 * 2 * pi)
-#' divided_diff(function(x) (x + 2)^2, seq(-5, 5, length.out = 100))
+#' m = 4 
+#' f = runif(m)
+#' z = runif(m)
+#' divided_diff(f[1], z[1])
+#' f[1]
+#' divided_diff(f[1:2], z[1:2])
+#' (f[1]-f[2])/(z[1]-z[2])
+#' divided_diff(f[1:3], z[1:3])
+#' ((f[1]-f[2])/(z[1]-z[2]) - (f[2]-f[3])/(z[2]-z[3])) / (z[1]-z[3]) 
+#' divided_diff(f, 1:m)
+#' diff(f, diff = m-1) / factorial(m-1)
 divided_diff <- function(f, z) {
   if (is.function(f)) f = sapply(z, f)
   else check_length(f, length(z))
@@ -92,10 +100,8 @@ divided_diff <- function(f, z) {
 #'   at design points.
 #' @export
 #' @examples
-#' xd <- 1:9
-#' discrete_deriv(sin, 2, xd, 1:8 + 0.5)
-#' discrete_deriv(cos, 2, xd, 1:8 + 0.5)
-#' discrete_deriv(function(x) (x + 2)^2, 2, -5:5, c(-2.5, 2.5))
+#' xd = 1:10
+#' discrete_deriv(function(x) x^2, 1, xd, xd)
 discrete_deriv <- function(f, k, xd, x) {
   check_nonneg_int(k)
   check_sorted(xd)
@@ -168,10 +174,8 @@ discrete_deriv <- function(f, k, xd, x) {
 #'   points.
 #' @export
 #' @examples
-#' xd <- 1:9
-#' discrete_integ(sin, 2, xd, 1:8 + 0.5)
-#' discrete_integ(cos, 2, xd, 1:8 + 0.5)
-#' discrete_integ(function(x) (x + 2)^2, 2, -5:5, c(-2.5, 2.5))
+#' xd = 1:10
+#' discrete_integ(function(x) 1, 1, xd, xd)
 discrete_integ <- function(f, k, xd, x) {
   check_nonneg_int(k)
   check_sorted(xd)

--- a/R/dot_functions.R
+++ b/R/dot_functions.R
@@ -35,10 +35,11 @@
 #'   matrix as returned by `h_mat()`. See also [h_mat_mult()].
 #' @return None. These functions *overwrite* their input.
 #' @examples
-#' v <- sort(runif(10))
+#' v = as.numeric(1:10) # Note: must be of numeric type
 #' v
-#' b_mat_mult(v, 2, 1:10)
-#' .b_mat_mult(v, 2, 1:10, FALSE, FALSE, FALSE)
+#' b_mat_mult(v, 1, 1:10) 
+#' v
+#' .b_mat_mult(v, 1, 1:10, FALSE, FALSE, FALSE)
 #' v
 NULL
 

--- a/R/dot_functions.R
+++ b/R/dot_functions.R
@@ -36,7 +36,6 @@
 #' @return None. These functions *overwrite* their input.
 #' @examples
 #' v = as.numeric(1:10) # Note: must be of numeric type
-#' v
 #' b_mat_mult(v, 1, 1:10) 
 #' v
 #' .b_mat_mult(v, 1, 1:10, FALSE, FALSE, FALSE)

--- a/R/interpolation.R
+++ b/R/interpolation.R
@@ -67,13 +67,15 @@
 #'   x_{(k+1):(n-1)}}).
 #' @export
 #' @examples
-#' xd <- 1:99 / 100
-#' v <- sin(2 * pi * xd) + rnorm(99, 0, .2)
-#' res <- dspline_solve(v, 2, xd, 1:9 * 10)
+#' xd = 1:99 / 100
+#' knot_idx = 1:9 * 10
+#' v = sin(2 * pi * xd) + rnorm(99, 0, .2)
+#' res = dspline_solve(v, 2, xd, knot_idx)
+#' x = 1:98 / 100 + 0.005 
+#' vhat = dspline_interp(res$fit, 2, xd, x)
 #' plot(xd, v, pch = 16)
-#' x <- 1:98 / 100 + 0.005 # locations in between `xd`
-#' vhat <- dspline_interp(res$fit, 2, xd, x)
 #' points(x, vhat, col = "firebrick")
+#' abline(v = xd[knot_idx], lty = 2)
 dspline_interp <- function(v, k, xd, x, implicit = TRUE) {
   check_nonneg_int(k)
   check_sorted(xd)

--- a/R/interpolation.R
+++ b/R/interpolation.R
@@ -69,12 +69,12 @@
 #' @examples
 #' xd = 1:100 / 100
 #' knot_idx = 1:9 * 10
-#' v = sin(2 * pi * xd) + rnorm(100, 0, .2)
-#' res = dspline_solve(v, 2, xd, knot_idx)
-#' x = 1:99 / 100 + 0.005 
-#' vhat = dspline_interp(res$fit, 2, xd, x)
-#' plot(xd, v, pch = 16)
-#' points(x, vhat, col = "firebrick")
+#' y = sin(2 * pi * xd) + rnorm(100, 0, 0.2)
+#' yhat = dspline_solve(y, 2, xd, knot_idx)$fit
+#' x = seq(0, 1, length = 1000)
+#' fhat = dspline_interp(yhat, 2, xd, x)
+#' plot(xd, y, pch = 16, col = "gray65")
+#' lines(x, fhat, col = "firebrick", lwd = 2)
 #' abline(v = xd[knot_idx], lty = 2)
 dspline_interp <- function(v, k, xd, x, implicit = TRUE) {
   check_nonneg_int(k)

--- a/R/interpolation.R
+++ b/R/interpolation.R
@@ -67,11 +67,11 @@
 #'   x_{(k+1):(n-1)}}).
 #' @export
 #' @examples
-#' xd = 1:99 / 100
+#' xd = 1:100 / 100
 #' knot_idx = 1:9 * 10
-#' v = sin(2 * pi * xd) + rnorm(99, 0, .2)
+#' v = sin(2 * pi * xd) + rnorm(100, 0, .2)
 #' res = dspline_solve(v, 2, xd, knot_idx)
-#' x = 1:98 / 100 + 0.005 
+#' x = 1:99 / 100 + 0.005 
 #' vhat = dspline_interp(res$fit, 2, xd, x)
 #' plot(xd, v, pch = 16)
 #' points(x, vhat, col = "firebrick")

--- a/R/matrix_construction.R
+++ b/R/matrix_construction.R
@@ -64,7 +64,7 @@
 #' @export
 #' @examples
 #' d_mat(2, 1:10)
-#' d_mat(2, 1:10 / 5)
+#' d_mat(2, 1:10 / 10)
 #' d_mat(2, 1:10, row_idx = 2:5)
 d_mat <- function(k, xd, tf_weighting = FALSE, row_idx = NULL) {
   check_nonneg_int(k)
@@ -152,7 +152,7 @@ d_mat <- function(k, xd, tf_weighting = FALSE, row_idx = NULL) {
 #' @export
 #' @examples
 #' b_mat(2, 1:10)
-#' b_mat(2, 1:10 / 5)
+#' b_mat(2, 1:10 / 10)
 #' b_mat(2, 1:10, row_idx = 4:7)
 b_mat <- function(k, xd, tf_weighting = FALSE, row_idx = NULL) {
   check_nonneg_int(k)
@@ -266,7 +266,7 @@ b_mat <- function(k, xd, tf_weighting = FALSE, row_idx = NULL) {
 #' @export
 #' @examples
 #' h_mat(2, 1:10)
-#' h_mat(2, 1:10 / 5)
+#' h_mat(2, 1:10 / 10)
 #' h_mat(2, 1:10, col_idx = 4:7)
 h_mat <- function(k, xd, di_weighting = FALSE, col_idx = NULL) {
   check_nonneg_int(k)

--- a/R/matrix_construction.R
+++ b/R/matrix_construction.R
@@ -65,7 +65,6 @@
 #' @examples
 #' d_mat(2, 1:10)
 #' d_mat(2, 1:10 / 5)
-#' d_mat(2, 1:10 / 5, TRUE)
 #' d_mat(2, 1:10, row_idx = 2:5)
 d_mat <- function(k, xd, tf_weighting = FALSE, row_idx = NULL) {
   check_nonneg_int(k)
@@ -154,8 +153,7 @@ d_mat <- function(k, xd, tf_weighting = FALSE, row_idx = NULL) {
 #' @examples
 #' b_mat(2, 1:10)
 #' b_mat(2, 1:10 / 5)
-#' b_mat(2, 1:10 / 5, TRUE)
-#' b_mat(2, 1:10, row_idx = 2:5)
+#' b_mat(2, 1:10, row_idx = 4:7)
 b_mat <- function(k, xd, tf_weighting = FALSE, row_idx = NULL) {
   check_nonneg_int(k)
   check_length(xd, k+1, ">=")
@@ -269,8 +267,7 @@ b_mat <- function(k, xd, tf_weighting = FALSE, row_idx = NULL) {
 #' @examples
 #' h_mat(2, 1:10)
 #' h_mat(2, 1:10 / 5)
-#' h_mat(2, 1:10 / 5, TRUE)
-#' h_mat(2, 1:10, col_idx = 2:5)
+#' h_mat(2, 1:10, col_idx = 4:7)
 h_mat <- function(k, xd, di_weighting = FALSE, col_idx = NULL) {
   check_nonneg_int(k)
   check_length(xd, k+1, ">=")
@@ -339,9 +336,8 @@ h_mat <- function(k, xd, di_weighting = FALSE, col_idx = NULL) {
 #' @importClassesFrom Matrix dgCMatrix
 #' @export
 #' @examples
-#' n_mat(2, 1:10, knot_idx = c(3, 4, 7))
-#' n_mat(2, 1:10, FALSE, knot_idx = c(3, 4, 7))
-#' n_mat(2, 1:10)
+#' n_mat(2, 1:10, knot_idx = c(3, 5, 7))
+#' n_mat(2, 1:10, knot_idx = c(4, 6, 8))
 n_mat <- function(k, xd, normalized = TRUE, knot_idx = NULL) {
   check_nonneg_int(k)
   check_length(xd, k+1, ">=")
@@ -354,7 +350,5 @@ n_mat <- function(k, xd, normalized = TRUE, knot_idx = NULL) {
     check_range(knot_idx, (k+1):(n-1))
     check_sorted(knot_idx)
   }
-
   rcpp_n_mat(k, xd, normalized, knot_idx-1)
-
 }

--- a/R/matrix_evaluation.R
+++ b/R/matrix_evaluation.R
@@ -27,8 +27,8 @@
 #'   basis at the design points.
 #' @export
 #' @examples
-#' xd <- 1:9 / 10
-#' x <- 1:8 / 10 + 0.05
+#' xd = 1:10 / 10
+#' x = 1:9 / 10 + 0.05
 #' h_mat(2, xd)
 #' h_eval(2, xd, x)
 h_eval <- function(k, xd, x, col_idx = NULL) {
@@ -93,10 +93,10 @@ h_eval <- function(k, xd, x, col_idx = NULL) {
 #' @importClassesFrom Matrix dgCMatrix
 #' @export
 #' @examples
-#' xd <- 1:9 / 10
-#' x <- 1:8 / 10 + 0.05
-#' n_mat(2, xd, knot_idx = c(3, 4, 7))
-#' n_eval(2, xd, x, knot_idx = c(3, 4, 7))
+#' xd = 1:10 / 10
+#' x = 1:9 / 10 + 0.05
+#' n_mat(2, xd, knot_idx = c(3, 5, 7))
+#' n_eval(2, xd, x, knot_idx = c(3, 5, 7))
 n_eval <- function(k, xd, x, normalized = TRUE, knot_idx = NULL, N = NULL) {
   check_nonneg_int(k)
   check_length(xd, k+1, ">=")

--- a/R/matrix_multiplication.R
+++ b/R/matrix_multiplication.R
@@ -51,9 +51,9 @@
 #'   matrix, and [d_mat()] for constructing the discrete derivative matrix.
 #' @export
 #' @examples
-#' v <- sort(runif(10))
+#' v = sort(runif(10))
 #' as.vector(d_mat(2, 1:10) %*% v)
-#' d_mat_mult(v, 2, 1:10) # more efficient
+#' d_mat_mult(v, 2, 1:10) 
 d_mat_mult <- function(v, k, xd, tf_weighting = FALSE, transpose = FALSE) {
   check_nonneg_int(k)
   check_sorted(xd)
@@ -126,9 +126,9 @@ d_mat_mult <- function(v, k, xd, tf_weighting = FALSE, transpose = FALSE) {
 #'   and [b_mat()] for constructing the extended discrete derivative matrix.
 #' @export
 #' @examples
-#' v <- sort(runif(10))
+#' v = sort(runif(10))
 #' as.vector(b_mat(2, 1:10) %*% v)
-#' b_mat_mult(v, 2, 1:10) # more efficient
+#' b_mat_mult(v, 2, 1:10) 
 b_mat_mult <- function(v, k, xd, tf_weighting = FALSE, transpose = FALSE,
                        inverse = FALSE) {
   check_nonneg_int(k)
@@ -202,9 +202,9 @@ b_mat_mult <- function(v, k, xd, tf_weighting = FALSE, transpose = FALSE,
 #'   points, and [h_mat()] for constructing the falling factorial basis matrix.
 #' @export
 #' @examples
-#' v <- sort(runif(10))
+#' v = sort(runif(10))
 #' as.vector(h_mat(2, 1:10) %*% v)
-#' h_mat_mult(v, 2, 1:10) # more efficient
+#' h_mat_mult(v, 2, 1:10) 
 h_mat_mult <- function(v, k, xd, di_weighting = FALSE, transpose = FALSE,
                        inverse = FALSE) {
   check_nonneg_int(k)

--- a/R/projection.R
+++ b/R/projection.R
@@ -72,12 +72,13 @@
 #'   discrete splines.
 #' @export
 #' @examples
-#' xd <- 1:99 / 100
-#' v <- sin(2 * pi * xd) + rnorm(99, 0, .2)
-#' res <- dspline_solve(v, 2, xd, 1:9 * 10)
-#' plot(xd, v, pch = 16)
-#' lines(xd, res$fit, col = "cornflowerblue")
-#' lines(xd, sin(2 * pi * xd), col = "firebrick")
+#' xd = 1:100 / 100
+#' knot_idx = 1:9 * 10
+#' y = sin(2 * pi * xd) + rnorm(100, 0, 0.2)
+#' yhat = res = dspline_solve(y, 2, xd, knot_idx)$fit
+#' plot(xd, y, pch = 16, col = "gray60")
+#' points(xd, yhat, col = "firebrick")
+#' abline(v = xd[knot_idx], lty = 2)
 dspline_solve <- function(v, k, xd, knot_idx, basis = c("N", "B", "H"), mat) {
   check_nonneg_int(k)
   check_sorted(xd)

--- a/README.Rmd
+++ b/README.Rmd
@@ -2,7 +2,7 @@
 output: github_document
 ---
 
-<!-- README.md is generated from README.Rmd. Please edit that file -->
+<!-- README.md is generated from README.Rmd. -->
 
 ```{r, include = FALSE}
 knitr::opts_chunk$set(
@@ -73,7 +73,8 @@ summary of the tools that are available.
 install.packages("dspline")
 ```
 
-You can install the development version of dspline from [GitHub](https://github.com/) with:
+You can install the development version of dspline from 
+[GitHub](https://github.com/) with:
 
 ``` r
 # install.packages("pak")

--- a/man/b_mat.Rd
+++ b/man/b_mat.Rd
@@ -81,7 +81,7 @@ forming any matrix in the first place).
 }
 \examples{
 b_mat(2, 1:10)
-b_mat(2, 1:10 / 5)
+b_mat(2, 1:10 / 10)
 b_mat(2, 1:10, row_idx = 4:7)
 }
 \references{

--- a/man/b_mat.Rd
+++ b/man/b_mat.Rd
@@ -82,8 +82,7 @@ forming any matrix in the first place).
 \examples{
 b_mat(2, 1:10)
 b_mat(2, 1:10 / 5)
-b_mat(2, 1:10 / 5, TRUE)
-b_mat(2, 1:10, row_idx = 2:5)
+b_mat(2, 1:10, row_idx = 4:7)
 }
 \references{
 Tibshirani (2020), "Divided differences, falling factorials, and

--- a/man/b_mat_mult.Rd
+++ b/man/b_mat_mult.Rd
@@ -70,9 +70,9 @@ performed in \eqn{O(nk)} operations. See Section 6.3 and Appendix D of
 Tibshirani (2020) for details.
 }
 \examples{
-v <- sort(runif(10))
+v = sort(runif(10))
 as.vector(b_mat(2, 1:10) \%*\% v)
-b_mat_mult(v, 2, 1:10) # more efficient
+b_mat_mult(v, 2, 1:10) 
 }
 \references{
 Tibshirani (2020), "Divided differences, falling factorials, and

--- a/man/d_mat.Rd
+++ b/man/d_mat.Rd
@@ -70,7 +70,7 @@ forming any matrix in the first place).
 }
 \examples{
 d_mat(2, 1:10)
-d_mat(2, 1:10 / 5)
+d_mat(2, 1:10 / 10)
 d_mat(2, 1:10, row_idx = 2:5)
 }
 \references{

--- a/man/d_mat.Rd
+++ b/man/d_mat.Rd
@@ -71,7 +71,6 @@ forming any matrix in the first place).
 \examples{
 d_mat(2, 1:10)
 d_mat(2, 1:10 / 5)
-d_mat(2, 1:10 / 5, TRUE)
 d_mat(2, 1:10, row_idx = 2:5)
 }
 \references{

--- a/man/d_mat_mult.Rd
+++ b/man/d_mat_mult.Rd
@@ -59,9 +59,9 @@ where \eqn{D^k f} is the \eqn{k}th derivative of \eqn{f}. See Section
 9.1. of Tibshirani (2020) for more details.
 }
 \examples{
-v <- sort(runif(10))
+v = sort(runif(10))
 as.vector(d_mat(2, 1:10) \%*\% v)
-d_mat_mult(v, 2, 1:10) # more efficient
+d_mat_mult(v, 2, 1:10) 
 }
 \references{
 Tibshirani (2020), "Divided differences, falling factorials, and

--- a/man/discrete_deriv.Rd
+++ b/man/discrete_deriv.Rd
@@ -57,7 +57,7 @@ will be more efficient (both will be linear-time, but the latter functions
 will be faster).
 }
 \examples{
-xd = 1:10
+xd = 1:10 / 10
 discrete_deriv(function(x) x^2, 1, xd, xd)
 }
 \references{

--- a/man/discrete_deriv.Rd
+++ b/man/discrete_deriv.Rd
@@ -57,10 +57,8 @@ will be more efficient (both will be linear-time, but the latter functions
 will be faster).
 }
 \examples{
-xd <- 1:9
-discrete_deriv(sin, 2, xd, 1:8 + 0.5)
-discrete_deriv(cos, 2, xd, 1:8 + 0.5)
-discrete_deriv(function(x) (x + 2)^2, 2, -5:5, c(-2.5, 2.5))
+xd = 1:10
+discrete_deriv(function(x) x^2, 1, xd, xd)
 }
 \references{
 Tibshirani (2020), "Divided differences, falling factorials, and

--- a/man/discrete_integ.Rd
+++ b/man/discrete_integ.Rd
@@ -68,10 +68,8 @@ should instead use \code{\link[=h_mat_mult]{h_mat_mult()}} with \code{di_weighti
 be \strong{much} more efficient (quadratic-time versus linear-time).
 }
 \examples{
-xd <- 1:9
-discrete_integ(sin, 2, xd, 1:8 + 0.5)
-discrete_integ(cos, 2, xd, 1:8 + 0.5)
-discrete_integ(function(x) (x + 2)^2, 2, -5:5, c(-2.5, 2.5))
+xd = 1:10
+discrete_integ(function(x) 1, 1, xd, xd)
 }
 \references{
 Tibshirani (2020), "Divided differences, falling factorials, and

--- a/man/discrete_integ.Rd
+++ b/man/discrete_integ.Rd
@@ -68,7 +68,7 @@ should instead use \code{\link[=h_mat_mult]{h_mat_mult()}} with \code{di_weighti
 be \strong{much} more efficient (quadratic-time versus linear-time).
 }
 \examples{
-xd = 1:10
+xd = 1:10 / 10
 discrete_integ(function(x) 1, 1, xd, xd)
 }
 \references{

--- a/man/divided_diff.Rd
+++ b/man/divided_diff.Rd
@@ -42,7 +42,14 @@ backward difference operators, respectively, of order \eqn{k} and with
 spacing \eqn{h}.
 }
 \examples{
-divided_diff(sin, 1:99 / 100 * 2 * pi)
-divided_diff(cos, 1:99 / 100 * 2 * pi)
-divided_diff(function(x) (x + 2)^2, seq(-5, 5, length.out = 100))
+f = runif(4)
+z = runif(4)
+divided_diff(f[1], z[1])
+f[1]
+divided_diff(f[1:2], z[1:2])
+(f[1]-f[2])/(z[1]-z[2])
+divided_diff(f[1:3], z[1:3])
+((f[1]-f[2])/(z[1]-z[2]) - (f[2]-f[3])/(z[2]-z[3])) / (z[1]-z[3]) 
+divided_diff(f, 1:4)
+diff(f, diff = 3) / factorial(3)
 }

--- a/man/dot_functions.Rd
+++ b/man/dot_functions.Rd
@@ -82,9 +82,10 @@ matrix as returned by \code{h_mat()}. See also \code{\link[=h_mat_mult]{h_mat_mu
 }
 
 \examples{
-v <- sort(runif(10))
+v = as.numeric(1:10) # Note: must be of numeric type
 v
-b_mat_mult(v, 2, 1:10)
-.b_mat_mult(v, 2, 1:10, FALSE, FALSE, FALSE)
+b_mat_mult(v, 1, 1:10) 
+v
+.b_mat_mult(v, 1, 1:10, FALSE, FALSE, FALSE)
 v
 }

--- a/man/dot_functions.Rd
+++ b/man/dot_functions.Rd
@@ -83,7 +83,6 @@ matrix as returned by \code{h_mat()}. See also \code{\link[=h_mat_mult]{h_mat_mu
 
 \examples{
 v = as.numeric(1:10) # Note: must be of numeric type
-v
 b_mat_mult(v, 1, 1:10) 
 v
 .b_mat_mult(v, 1, 1:10, FALSE, FALSE, FALSE)

--- a/man/dspline-package.Rd
+++ b/man/dspline-package.Rd
@@ -6,7 +6,7 @@
 \alias{dspline-package}
 \title{dspline: Tools for Computations with Discrete Splines}
 \description{
-Discrete splines are a class of univariate piecewise polynomial functions with close connections to divided differences and Newton interpolation. Tools for efficient computations relating to discrete splines are provided here. These tools include discrete differentiation and integration, various matrix computations with discrete derivative or discrete spline bases matrices, and interpolation within discrete spline spaces. Many of these techniques are described in Tibshirani (2020) \href{https://arxiv.org/abs/2003.03886}{arXiv:2003.03886}.
+Discrete splines are a class of univariate piecewise polynomial functions which are analogous to splines, but whose smoothness is defined via divided differences rather than derivatives. Tools for efficient computations relating to discrete splines are provided here. These tools include discrete differentiation and integration, various matrix computations with discrete derivative or discrete spline bases matrices, and interpolation within discrete spline spaces. These techniques are described in Tibshirani (2020) \href{https://arxiv.org/abs/2003.03886}{arXiv:2003.03886}.
 }
 \seealso{
 Useful links:
@@ -28,6 +28,7 @@ Authors:
 Other contributors:
 \itemize{
   \item Logan Brooks [contributor]
+  \item Daniel McDonald [contributor]
 }
 
 }

--- a/man/dspline_interp.Rd
+++ b/man/dspline_interp.Rd
@@ -75,13 +75,15 @@ generally a more efficient and stable scheme for interpolation. See Section
 5.4 of Tibshirani (2020) for more details.
 }
 \examples{
-xd <- 1:99 / 100
-v <- sin(2 * pi * xd) + rnorm(99, 0, .2)
-res <- dspline_solve(v, 2, xd, 1:9 * 10)
+xd = 1:99 / 100
+knot_idx = 1:9 * 10
+v = sin(2 * pi * xd) + rnorm(99, 0, .2)
+res = dspline_solve(v, 2, xd, knot_idx)
+x = 1:98 / 100 + 0.005 
+vhat = dspline_interp(res$fit, 2, xd, x)
 plot(xd, v, pch = 16)
-x <- 1:98 / 100 + 0.005 # locations in between `xd`
-vhat <- dspline_interp(res$fit, 2, xd, x)
 points(x, vhat, col = "firebrick")
+abline(v = xd[knot_idx], lty = 2)
 }
 \references{
 Tibshirani (2020), "Divided differences, falling factorials, and

--- a/man/dspline_interp.Rd
+++ b/man/dspline_interp.Rd
@@ -75,14 +75,14 @@ generally a more efficient and stable scheme for interpolation. See Section
 5.4 of Tibshirani (2020) for more details.
 }
 \examples{
-xd = 1:99 / 100
+xd = 1:100 / 100
 knot_idx = 1:9 * 10
-v = sin(2 * pi * xd) + rnorm(99, 0, .2)
-res = dspline_solve(v, 2, xd, knot_idx)
-x = 1:98 / 100 + 0.005 
-vhat = dspline_interp(res$fit, 2, xd, x)
-plot(xd, v, pch = 16)
-points(x, vhat, col = "firebrick")
+y = sin(2 * pi * xd) + rnorm(100, 0, 0.2)
+yhat = dspline_solve(y, 2, xd, knot_idx)$fit
+x = seq(0, 1, length = 1000)
+fhat = dspline_interp(yhat, 2, xd, x)
+plot(xd, y, pch = 16, col = "gray65")
+lines(x, fhat, col = "firebrick", lwd = 2)
 abline(v = xd[knot_idx], lty = 2)
 }
 \references{

--- a/man/dspline_solve.Rd
+++ b/man/dspline_solve.Rd
@@ -81,12 +81,13 @@ knots in the discrete spline space and the complementary set of roles play
 a role in computing the solution. See Section 8.1 of Tibshirani (2020).
 }
 \examples{
-xd <- 1:99 / 100
-v <- sin(2 * pi * xd) + rnorm(99, 0, .2)
-res <- dspline_solve(v, 2, xd, 1:9 * 10)
-plot(xd, v, pch = 16)
-lines(xd, res$fit, col = "cornflowerblue")
-lines(xd, sin(2 * pi * xd), col = "firebrick")
+xd = 1:100 / 100
+knot_idx = 1:9 * 10
+y = sin(2 * pi * xd) + rnorm(100, 0, 0.2)
+yhat = res = dspline_solve(y, 2, xd, knot_idx)$fit
+plot(xd, y, pch = 16, col = "gray60")
+points(xd, yhat, col = "firebrick")
+abline(v = xd[knot_idx], lty = 2)
 }
 \references{
 Tibshirani (2020), "Divided differences, falling factorials, and

--- a/man/h_eval.Rd
+++ b/man/h_eval.Rd
@@ -38,8 +38,8 @@ row with entries:
   }
 }
 \examples{
-xd <- 1:9 / 10
-x <- 1:8 / 10 + 0.05
+xd = 1:10 / 10
+x = 1:9 / 10 + 0.05
 h_mat(2, xd)
 h_eval(2, xd, x)
 }

--- a/man/h_mat.Rd
+++ b/man/h_mat.Rd
@@ -106,7 +106,7 @@ multiplication, but instead use \code{\link[=h_mat_mult]{h_mat_mult()}}, as the 
 }
 \examples{
 h_mat(2, 1:10)
-h_mat(2, 1:10 / 5)
+h_mat(2, 1:10 / 10)
 h_mat(2, 1:10, col_idx = 4:7)
 }
 \references{

--- a/man/h_mat.Rd
+++ b/man/h_mat.Rd
@@ -107,8 +107,7 @@ multiplication, but instead use \code{\link[=h_mat_mult]{h_mat_mult()}}, as the 
 \examples{
 h_mat(2, 1:10)
 h_mat(2, 1:10 / 5)
-h_mat(2, 1:10 / 5, TRUE)
-h_mat(2, 1:10, col_idx = 2:5)
+h_mat(2, 1:10, col_idx = 4:7)
 }
 \references{
 Tibshirani (2020), "Divided differences, falling factorials, and

--- a/man/h_mat_mult.Rd
+++ b/man/h_mat_mult.Rd
@@ -72,9 +72,9 @@ that multiplying by \eqn{(H^k_n)^{-1}} or its transpose can be performed in
 for details.
 }
 \examples{
-v <- sort(runif(10))
+v = sort(runif(10))
 as.vector(h_mat(2, 1:10) \%*\% v)
-h_mat_mult(v, 2, 1:10) # more efficient
+h_mat_mult(v, 2, 1:10) 
 }
 \references{
 Tibshirani (2020), "Divided differences, falling factorials, and

--- a/man/n_eval.Rd
+++ b/man/n_eval.Rd
@@ -60,10 +60,10 @@ points, the fast interpolation scheme from \code{\link[=dspline_interp]{dspline_
 produce evaluations at the query points.
 }
 \examples{
-xd <- 1:9 / 10
-x <- 1:8 / 10 + 0.05
-n_mat(2, xd, knot_idx = c(3, 4, 7))
-n_eval(2, xd, x, knot_idx = c(3, 4, 7))
+xd = 1:10 / 10
+x = 1:9 / 10 + 0.05
+n_mat(2, xd, knot_idx = c(3, 5, 7))
+n_eval(2, xd, x, knot_idx = c(3, 5, 7))
 }
 \seealso{
 \code{\link[=n_mat]{n_mat()}} for constructing evaluations of the discrete B-spline

--- a/man/n_mat.Rd
+++ b/man/n_mat.Rd
@@ -61,8 +61,8 @@ sets \eqn{T} that are proper subsets of \eqn{x_{(k+1):(n-1)}}.
 Specification of the knot set \eqn{T} is done via the argument \code{knot_idx}.
 }
 \examples{
-n_mat(2, 1:10, knot_idx = c(3,5,7))
-n_mat(2, 1:10, knot_idx = c(4,6,8))
+n_mat(2, 1:10, knot_idx = c(3, 5, 7))
+n_mat(2, 1:10, knot_idx = c(4, 6, 8))
 }
 \references{
 Tibshirani (2020), "Divided differences, falling factorials, and

--- a/man/n_mat.Rd
+++ b/man/n_mat.Rd
@@ -61,9 +61,8 @@ sets \eqn{T} that are proper subsets of \eqn{x_{(k+1):(n-1)}}.
 Specification of the knot set \eqn{T} is done via the argument \code{knot_idx}.
 }
 \examples{
-n_mat(2, 1:10, knot_idx = c(3, 4, 7))
-n_mat(2, 1:10, FALSE, knot_idx = c(3, 4, 7))
-n_mat(2, 1:10)
+n_mat(2, 1:10, knot_idx = c(3,5,7))
+n_mat(2, 1:10, knot_idx = c(4,6,8))
 }
 \references{
 Tibshirani (2020), "Divided differences, falling factorials, and

--- a/src/matrix_construction.cpp
+++ b/src/matrix_construction.cpp
@@ -135,8 +135,8 @@ Eigen::SparseMatrix<double> rcpp_n_mat(int k, NumericVector xd, bool normalized,
   n_mat.setFromTriplets(n_list.begin(), n_list.end());
   // Rescale columns to have largest value 1 if necessary
   if (normalized) {
-    // Canonical matrix-vector broadcasting in Eigen is done via arrays
-    // (see, e.g., https://eigen.tuxfamily.org/dox/group__TutorialArrayClass.html).
+    // Canonical matrix-vector broadcasting in Eigen is done via arrays (see,
+    // e.g., https://eigen.tuxfamily.org/dox/group__TutorialArrayClass.html).
     // However, sparse matrices cannot be converted to arrays, so here we
     // perform column scaling via right-multiplication by a diagonal matrix.
     n_mat = n_mat * max_vals.cwiseInverse().asDiagonal();


### PR DESCRIPTION
I just touched up the examples lightly. They were mostly great --- thank you @dajmcdon!

Only one that was a little off was the examples for `divided_diff()`: note that this function performs a divided difference of order equals to the number of points in the second argument `z` (the centers) minus 1, so the existing examples were performing something like a divided difference or order 99 (analogous to a derivative of order 99).